### PR TITLE
add zora mask requirement to zora hall torches

### DIFF
--- a/worlds/mm_recomp/NormalRules.py
+++ b/worlds/mm_recomp/NormalRules.py
@@ -797,7 +797,7 @@ def get_location_rules(player, options):
         "Zora Hall Piano Zora Song":
             lambda state: state.has("Zora Mask", player),
         "Zora Hall Torches Reward":
-            lambda state: can_use_fire_arrows(state, player),
+            lambda state: state.has("Zora Mask", player) and can_use_fire_arrows(state, player),
         "Zora Hall Good Picture of Lulu":
            lambda state: state.has("Pictograph Box", player) and state.has("Zora Mask", player),
         "Zora Hall Bad Picture of Lulu":

--- a/worlds/mm_recomp/Rules.py
+++ b/worlds/mm_recomp/Rules.py
@@ -825,7 +825,7 @@ def get_baby_location_rules(player, options):
         "Zora Hall Piano Zora Song":
             lambda state: state.has("Zora Mask", player),
         "Zora Hall Torches Reward":
-           lambda state: can_use_fire_arrows(state, player),
+           lambda state: state.has("Zora Mask", player) and can_use_fire_arrows(state, player),
         "Zora Hall Good Picture of Lulu":
            lambda state: state.has("Pictograph Box", player) and state.has("Zora Mask", player),
         "Zora Hall Bad Picture of Lulu":


### PR DESCRIPTION
Reaching Zora Hall at all should require the Zora Mask, because of the skeleton fishes that harass Link on the way.
You can make it there on low health by swimming sideways, but it's definitely obscure