### PR TITLE
Add missing access rule to entrace "Beneath the Well -> Ikana Castle"

### DIFF
--- a/worlds/mm_recomp/NormalRules.py
+++ b/worlds/mm_recomp/NormalRules.py
@@ -261,6 +261,24 @@ def get_region_rules(player, options):
                     has_mirror_shield(state, player)
                 )
             ),
+        "Beneath the Well -> Ikana Castle":
+            lambda state: (
+                ( # Ikana Well Final Chest Logic
+                    state.has("Gibdo Mask", player) and 
+                    has_bottle(state, player) and 
+                    can_plant_beans(state, player) and 
+                    (
+                        state.has("Progressive Bomb Bag", player) or 
+                        (
+                            state.has("Captain's Hat", player) and 
+                            state.has("Progressive Bow", player)
+                        )
+                    )
+                ) and (
+                    can_use_light_arrows(state, player) or 
+                    has_mirror_shield(state, player)
+                )
+            ),
         "Stone Tower -> Stone Tower Temple":
             lambda state: (
                 can_reach_stonetower(state, player)


### PR DESCRIPTION
We got an impossible seed. Ikana Castle was wrongly marked as accessible through beneath the well, but neither Light Arrows nor Mirror Shield were accessible without collecting Pillar HP in Ikana Castle.

We believe this was caused by `get_region_rules` containing no access rule for `Beneath the Well -> Ikana Castle` leaving it as an always accessible entrance, which makes `Ikana Canyon -> Beneath the Well -> Ikana Castle` logically accesible.

This should be fixed by the new rule in the PR comprising two parts:
 - Logic for getting to the final room based on Final Chest Logic
 - Exiting the Final Room by removing the sun block
