### PR TITLE
Region and Check Access for Road to Ikana and Path to Snowhead

### DIFF
--- a/worlds/mm_recomp/Locations.py
+++ b/worlds/mm_recomp/Locations.py
@@ -13328,22 +13328,22 @@ location_data_table: Dict[str, MMRLocationData] = {
 
     # Outside Snowhead Temple Snowballs
     "Outside Snowhead Temple Snowballs (0)": MMRLocationData(
-        region="Snowhead Temple",
+        region="Snowhead",
         address=0x3469420215C01,
         can_create=lambda options: options.snowsanity.value
     ),
     "Outside Snowhead Temple Snowballs (1)": MMRLocationData(
-        region="Snowhead Temple",
+        region="Snowhead",
         address=0x3469420215C03,
         can_create=lambda options: options.snowsanity.value
     ),
     "Outside Snowhead Temple Snowballs (2)": MMRLocationData(
-        region="Snowhead Temple",
+        region="Snowhead",
         address=0x3469420215C00,
         can_create=lambda options: options.snowsanity.value
     ),
     "Outside Snowhead Temple Snowballs (3)": MMRLocationData(
-        region="Snowhead Temple",
+        region="Snowhead",
         address=0x3469420215C02,
         can_create=lambda options: options.snowsanity.value
     ),
@@ -16967,7 +16967,7 @@ location_data_table: Dict[str, MMRLocationData] = {
         can_create=lambda options: options.signsanity.value
     ),
     "Outside Snowhead Temple Cut the Sign": MMRLocationData(
-        region="Path to Snowhead",
+        region="Snowhead",
         address=0x3469420310320,
         can_create=lambda options: options.signsanity.value
     ),

--- a/worlds/mm_recomp/Locations.py
+++ b/worlds/mm_recomp/Locations.py
@@ -14325,17 +14325,17 @@ location_data_table: Dict[str, MMRLocationData] = {
     ),
     "Snowhead Temple Entry Block Icicles (2)": MMRLocationData(
         region="Snowhead Temple",
-        address=0x3469420232101,
+        address=0x3469420232105,
         can_create=lambda options: options.iciclesanity.value
     ),
     "Snowhead Temple Entry Block Icicles (3)": MMRLocationData(
         region="Snowhead Temple",
-        address=0x3469420232102,
+        address=0x3469420232101,
         can_create=lambda options: options.iciclesanity.value
     ),
     "Snowhead Temple Entry Block Icicles (4)": MMRLocationData(
         region="Snowhead Temple",
-        address=0x3469420232103,
+        address=0x3469420232106,
         can_create=lambda options: options.iciclesanity.value
     ),
     "Snowhead Temple Entry Block Icicles (5)": MMRLocationData(
@@ -14345,22 +14345,22 @@ location_data_table: Dict[str, MMRLocationData] = {
     ),
     "Snowhead Temple Grey Door Icicles (1)": MMRLocationData(
         region="Snowhead Temple",
-        address=0x3469420232105,
+        address=0x3469420232103,
         can_create=lambda options: options.iciclesanity.value
     ),
     "Snowhead Temple Grey Door Icicles (2)": MMRLocationData(
         region="Snowhead Temple",
-        address=0x3469420232106,
+        address=0x3469420232102,
         can_create=lambda options: options.iciclesanity.value
     ),
     "Snowhead Temple Grey Door Ceiling Icicles (1)": MMRLocationData(
         region="Snowhead Temple",
-        address=0x3469420232107,
+        address=0x3469420232108,
         can_create=lambda options: options.iciclesanity.value
     ),
     "Snowhead Temple Grey Door Ceiling Icicles (2)": MMRLocationData(
         region="Snowhead Temple",
-        address=0x3469420232108,
+        address=0x3469420232107,
         can_create=lambda options: options.iciclesanity.value
     ),
     "Snowhead Temple Frozen Block Ceiling Icicle (1)": MMRLocationData(

--- a/worlds/mm_recomp/NormalRules.py
+++ b/worlds/mm_recomp/NormalRules.py
@@ -15235,7 +15235,8 @@ def get_location_rules(player, options):
                 state.can_reach("Snowhead", 'Region', player) and
                 (
                     state.has("Goron Mask", player) or
-                    has_explosives(state, player)
+                    has_explosives(state, player) or
+                    can_use_fire_arrows(state, player)
                 )
         ),
         "Path to Snowhead Snowballs (3)":
@@ -15249,7 +15250,8 @@ def get_location_rules(player, options):
                 state.can_reach("Snowhead", 'Region', player) and
                 (
                     state.has("Goron Mask", player) or
-                    has_explosives(state, player)
+                    has_explosives(state, player) or
+                    can_use_fire_arrows(state, player)
                 )
         ),
         # Outside Snowhead Temple Snowballs

--- a/worlds/mm_recomp/NormalRules.py
+++ b/worlds/mm_recomp/NormalRules.py
@@ -727,17 +727,6 @@ def get_region_rules(player, options):
                         options.remains_allow_boss_warps.value
                     )
             ),
-        "Termina Field -> Road to Ikana":
-            lambda state: (
-                can_play_song("Epona's Song", state, player) or
-                (
-                    options.owlsanity.value and
-                    (
-                        can_use_owl(state, player, options, "Ikana Canyon") or
-                        can_use_owl(state, player, options, "Stone Tower")
-                    )
-                )
-            ),
         "Road to Ikana -> Termina Field":
             lambda state: (
                 can_play_song("Epona's Song", state, player) or
@@ -11350,10 +11339,14 @@ def get_location_rules(player, options):
         "Road To Ikana Scarecrow Pillar Pot":
             lambda state: (
                 has_soul_absurd(state, player, options, "Pots") and 
-                can_play_song("Epona's Song", state, player) and
                 state.has("Hookshot", player) and
                 can_reach_scarecrow(state, player, options) and
-                state.has("Road to Ikana Scarecrow", player)
+                state.has("Road to Ikana Scarecrow", player) and
+                (
+                    can_play_song("Epona's Song", state, player) or
+                    can_use_owl(state, player, options, "Ikana Canyon") or
+                    can_use_owl(state, player, options, "Stone Tower")
+                )
             ),
         # Ikana Graveyard Day 1 Grave Pots
         "Ikana Graveyard Day 1 Grave Pots (1)":

--- a/worlds/mm_recomp/NormalRules.py
+++ b/worlds/mm_recomp/NormalRules.py
@@ -2527,7 +2527,10 @@ def get_location_rules(player, options):
                 has_bottle(state, player) and 
                 (
                     can_reach_seahorse(state, player, options) or
-                    state.can_reach("Pirates' Fortress Leader's Room Chest", "Location", player)
+                    (
+                        state.can_reach("Pirates' Fortress Leader's Room Chest", "Location", player) and
+                        state.has("Hookshot", player)
+                    )
                 )
             ),
         "Great Bay Feeding Lab Fish":

--- a/worlds/mm_recomp/NormalRules.py
+++ b/worlds/mm_recomp/NormalRules.py
@@ -613,11 +613,6 @@ def get_region_rules(player, options):
                 (state.has("Powder Keg", player) or
                 can_use_fire_arrows(state, player))
             ),
-        "Mountain Village -> Path to Snowhead": 
-            lambda state: (
-                state.has("Goron Mask", player) and 
-                state.has("Progressive Magic", player)
-            ),
         "Path to Snowhead -> Snowhead":
             lambda state: (
                 (
@@ -634,7 +629,7 @@ def get_region_rules(player, options):
                     state.has("Goron Mask", player) and 
                     state.has("Progressive Magic", player)
                 ) or
-                can_use_owl(state, player, options, "Snowhead") and
+                can_use_owl(state, player, options, "Mountain Village") and
                 can_warp_out(state, player, options)
             ),
         "Snowhead -> Snowhead Temple": lambda state: (
@@ -2202,15 +2197,14 @@ def get_location_rules(player, options):
         "Path to Snowhead Grotto Chest":
             lambda state: (
                 has_soul_absurd(state, player, options, "Grottos") and
-                state.has("Goron Mask", player) and 
-                state.has("Progressive Magic", player) and 
+                state.can_reach("Snowhead", 'Region', player) 
                 has_explosives(state, player)
             ),
         "Path to Snowhead Scarecrow Pillar HP":
             lambda state: (
                 can_reach_scarecrow(state, player, options) and 
                 state.has("Path to Snowhead Scarecrow", player) and
-                state.has("Goron Mask", player) and 
+                state.can_reach("Snowhead", 'Region', player) and 
                 can_use_lens(state, player) and 
                 state.has("Hookshot", player)
             ),
@@ -6795,117 +6789,103 @@ def get_location_rules(player, options):
         "Goron Village Lens Cave Grass (24)":
             lambda state: has_soul_absurd(state, player, options, "Grass"),
 
-        # Path To Snowhead Grotto Grass - Requires Goron Mask, Magic, and Explosives
+        # Path To Snowhead Grotto Grass - Requires Explosives and either Goron and Magic or Snowhead
         "Path To Snowhead Grotto Grass (1)":
             lambda state: (
                 has_soul_absurd(state, player, options, "Grottos") and 
                 has_soul_absurd(state, player, options, "Grass") and
-                state.has("Goron Mask", player) and 
-                state.has("Progressive Magic", player) and 
+                state.can_reach("Snowhead", 'Region', player) and 
                 has_explosives(state, player)
             ),
         "Path To Snowhead Grotto Grass (2)":
             lambda state: (
                 has_soul_absurd(state, player, options, "Grottos") and 
                 has_soul_absurd(state, player, options, "Grass") and
-                state.has("Goron Mask", player) and 
-                state.has("Progressive Magic", player) and 
+                state.can_reach("Snowhead", 'Region', player) and 
                 has_explosives(state, player)
             ),
         "Path To Snowhead Grotto Grass (3)":
             lambda state: (
                 has_soul_absurd(state, player, options, "Grottos") and 
                 has_soul_absurd(state, player, options, "Grass") and
-                state.has("Goron Mask", player) and 
-                state.has("Progressive Magic", player) and 
+                state.can_reach("Snowhead", 'Region', player) and 
                 has_explosives(state, player)
             ),
         "Path To Snowhead Grotto Grass (4)":
             lambda state: (
                 has_soul_absurd(state, player, options, "Grottos") and 
                 has_soul_absurd(state, player, options, "Grass") and
-                state.has("Goron Mask", player) and 
-                state.has("Progressive Magic", player) and 
+                state.can_reach("Snowhead", 'Region', player) and 
                 has_explosives(state, player)
             ),
         "Path To Snowhead Grotto Grass (5)":
             lambda state: (
                 has_soul_absurd(state, player, options, "Grottos") and 
                 has_soul_absurd(state, player, options, "Grass") and
-                state.has("Goron Mask", player) and 
-                state.has("Progressive Magic", player) and 
+                state.can_reach("Snowhead", 'Region', player) and 
                 has_explosives(state, player)
             ),
         "Path To Snowhead Grotto Grass (6)":
             lambda state: (
                 has_soul_absurd(state, player, options, "Grottos") and 
                 has_soul_absurd(state, player, options, "Grass") and
-                state.has("Goron Mask", player) and 
-                state.has("Progressive Magic", player) and 
+                state.can_reach("Snowhead", 'Region', player) and 
                 has_explosives(state, player)
             ),
         "Path To Snowhead Grotto Grass (7)":
             lambda state: (
                 has_soul_absurd(state, player, options, "Grottos") and 
                 has_soul_absurd(state, player, options, "Grass") and
-                state.has("Goron Mask", player) and 
-                state.has("Progressive Magic", player) and 
+                state.can_reach("Snowhead", 'Region', player) and 
                 has_explosives(state, player)
             ),
         "Path To Snowhead Grotto Grass (8)":
             lambda state: (
                 has_soul_absurd(state, player, options, "Grottos") and 
                 has_soul_absurd(state, player, options, "Grass") and
-                state.has("Goron Mask", player) and 
-                state.has("Progressive Magic", player) and 
+                state.can_reach("Snowhead", 'Region', player) and 
                 has_explosives(state, player)
             ),
         "Path To Snowhead Grotto Grass (9)":
             lambda state: (
                 has_soul_absurd(state, player, options, "Grottos") and 
                 has_soul_absurd(state, player, options, "Grass") and
-                state.has("Goron Mask", player) and 
-                state.has("Progressive Magic", player) and 
+                state.can_reach("Snowhead", 'Region', player) and 
                 has_explosives(state, player)
             ),
         "Path To Snowhead Grotto Grass (10)":
             lambda state: (
                 has_soul_absurd(state, player, options, "Grottos") and 
                 has_soul_absurd(state, player, options, "Grass") and
-                state.has("Goron Mask", player) and 
-                state.has("Progressive Magic", player) and 
+                state.can_reach("Snowhead", 'Region', player) and 
                 has_explosives(state, player)
             ),
         "Path To Snowhead Grotto Grass (11)":
             lambda state: (
                 has_soul_absurd(state, player, options, "Grottos") and 
                 has_soul_absurd(state, player, options, "Grass") and
-                state.has("Goron Mask", player) and 
-                state.has("Progressive Magic", player) and 
+                state.can_reach("Snowhead", 'Region', player) and 
                 has_explosives(state, player)
             ),
         "Path To Snowhead Grotto Grass (12)":
             lambda state: (
                 has_soul_absurd(state, player, options, "Grottos") and 
                 has_soul_absurd(state, player, options, "Grass") and
-                state.has("Goron Mask", player) and 
-                state.has("Progressive Magic", player) and 
+                state.can_reach("Snowhead", 'Region', player) and 
                 has_explosives(state, player)
             ),
         "Path To Snowhead Grotto Grass (13)":
             lambda state: (
                 has_soul_absurd(state, player, options, "Grottos") and 
                 has_soul_absurd(state, player, options, "Grass") and
-                state.has("Goron Mask", player) and 
-                state.has("Progressive Magic", player) and 
+                state.can_reach("Snowhead", 'Region', player) and 
                 has_explosives(state, player)
             ),
         "Path To Snowhead Grotto Grass (14)":
             lambda state: (
                 has_soul_absurd(state, player, options, "Grottos") and 
                 has_soul_absurd(state, player, options, "Grass") and
-                state.has("Goron Mask", player) and 
-                state.has("Progressive Magic", player) and 
+                state.can_reach("Snowhead", 'Region', player) and 
                 has_explosives(state, player)
             ),
 
@@ -15249,28 +15229,25 @@ def get_location_rules(player, options):
         ),
         "Path to Snowhead Snowballs (2)":
             lambda state: (
-                state.has("Goron Mask", player) and
-                 state.has("Progressive Magic", player)
+                state.can_reach("Snowhead", 'Region', player) and
+                (
+                    state.has("Goron Mask", player) or
+                    has_explosives(state, player)
+                )
         ),
         "Path to Snowhead Snowballs (3)":
-            lambda state: (
-                state.has("Goron Mask", player) and
-                 state.has("Progressive Magic", player)
-        ),
+            lambda state: state.can_reach("Snowhead", 'Region', player),
         "Path to Snowhead Snowballs (4)":
-            lambda state: (
-                state.has("Goron Mask", player) and
-                 state.has("Progressive Magic", player)
-        ),
+            lambda state: state.can_reach("Snowhead", 'Region', player),
         "Path to Snowhead Snowballs (5)":
-            lambda state: (
-                state.has("Goron Mask", player) and
-                 state.has("Progressive Magic", player)
-        ),
+            lambda state: state.can_reach("Snowhead", 'Region', player),
         "Path to Snowhead Snowballs (6)":
             lambda state: (
-                state.has("Goron Mask", player) and
-                 state.has("Progressive Magic", player)
+                state.can_reach("Snowhead", 'Region', player) and
+                (
+                    state.has("Goron Mask", player) or
+                    has_explosives(state, player)
+                )
         ),
         # Outside Snowhead Temple Snowballs
         "Outside Snowhead Temple Snowballs (0)":
@@ -17311,14 +17288,17 @@ def get_location_rules(player, options):
             lambda state: (
                 can_use_lens(state, player) and
                 has_soul_npc(state, player, options, "Scarecrow") and
-                state.has("Ocarina of Time", player)
+                state.has("Ocarina of Time", player) and
+                state.can_reach("Snowhead", 'Region', player)
             ),
         "Path to Snowhead Spring Scarecrow":
             lambda state: (
                 has_soul_npc(state, player, options, "Scarecrow") and
                 state.has("Ocarina of Time", player) and
                 can_use_lens(state, player) and
-                can_clear_snowhead(state, player)
+                can_clear_snowhead(state, player) and
+                state.can_reach("Snowhead", 'Region', player)
+
             ),
         # Twin Islands Scarecrows
         "Twin Islands Scarecrow":
@@ -18582,11 +18562,20 @@ def get_location_rules(player, options):
 
         # Path To Snowhead - 
         "Path To Snowhead Tree (1)":
-            lambda state: has_soul_absurd(state, player, options, "Trees & Bushes"),
+            lambda state: (
+                has_soul_absurd(state, player, options, "Trees & Bushes") and
+                state.can_reach("Mountain Village", 'Region', player)
+            ),
         "Path To Snowhead Tree (2)":
-            lambda state: has_soul_absurd(state, player, options, "Trees & Bushes"),
+            lambda state: (
+                has_soul_absurd(state, player, options, "Trees & Bushes") and
+                state.can_reach("Mountain Village", 'Region', player)
+            ),
         "Path To Snowhead Tree (3)":
-            lambda state: has_soul_absurd(state, player, options, "Trees & Bushes"),
+            lambda state: (
+                has_soul_absurd(state, player, options, "Trees & Bushes") and
+                state.can_reach("Mountain Village", 'Region', player)
+            ),
 
         # Goron Racetrack - 
         "Goron Racetrack Trees (1)":
@@ -20204,9 +20193,15 @@ def get_location_rules(player, options):
         "Goron Village Outside Goron Shrine":
             lambda state: has_soul_absurd(state, player, options, "Signs"),
         "Path to Snowhead Cut the Sign":
-            lambda state: has_soul_absurd(state, player, options, "Signs"),
+            lambda state: (
+                has_soul_absurd(state, player, options, "Signs") and
+                state.can_reach("Mountain Village", 'Region', player)
+            ),
         "Path to Snowhead Upper Cut the Sign":
-            lambda state: has_soul_absurd(state, player, options, "Signs"),
+            lambda state: (
+                has_soul_absurd(state, player, options, "Signs") and
+                state.can_reach("Snowhead", 'Region', player)
+            ),
         "Outside Snowhead Temple Cut the Sign":
             lambda state: has_soul_absurd(state, player, options, "Signs"),
         "Mountain Village Owl Statue Spring Cut the Sign":


### PR DESCRIPTION
Passover to adjust Region Access Rules for Road to Ikana and Path to Snowhead to remove extra logic requirements. Road to Ikana was requiring player could play Epona's Song for Pillar Chest and Goron Boulder/Grotto which appear prior to the first gate.
Path to Snowhead required Goron and Progressive Magic to put anything into logic, which with owlsanity can access a chunk of it without either.
Snowhead has 4 snowballs and the sign that is accessible from the owl statue without a need for anything more than ability to soar to snowhead and warp out, so adjusted their regions.

Also I have added Hookshot for access requirement to PFI Eggs, as current logic can expect the player to obtain those eggs without hookshot if they are able to go through the Sewers