### PR TITLE
Add Missing Hookshot for Zora Eggs

### DIFF
--- a/worlds/mm_recomp/NormalRules.py
+++ b/worlds/mm_recomp/NormalRules.py
@@ -1566,7 +1566,10 @@ def get_location_rules(player, options, prices):
                 has_bottle(state, player) and 
                 (
                     can_reach_seahorse(state, player) or
-                    state.can_reach("Pirates' Fortress Leader's Room Chest", "Location", player)
+                    (
+                        state.can_reach("Pirates' Fortress Leader's Room Chest", "Location", player) and
+                        state.has("Hookshot", player)
+                    )
                 )
             ),
         "Great Bay Feeding Lab Fish":


### PR DESCRIPTION
Zora Eggs missing Hookshot requirement to go with Pirate Fortress Eggs access