### PR TITLE
Fix STT Eyegore Room Crates Logic

### DIFF
--- a/worlds/mm_recomp/NormalRules.py
+++ b/worlds/mm_recomp/NormalRules.py
@@ -16832,7 +16832,11 @@ def get_location_rules(player, options):
             lambda state: (
                 state.has("Zora Mask", player) and
                 (
-                    state.has("Goron Mask", player) or
+                    (
+                        state.has("Goron Mask", player) and
+                        state.has("Small Key (Stone Tower)", player, 1) and
+                        has_explosives(state, player)
+                    ) or
                     can_use_light_arrows(state, player)
                 )
             ),
@@ -16840,15 +16844,23 @@ def get_location_rules(player, options):
             lambda state: (
                 state.has("Zora Mask", player) and
                 (
-                    state.has("Goron Mask", player) or
+                    (
+                        state.has("Goron Mask", player) and
+                        state.has("Small Key (Stone Tower)", player, 1) and
+                        has_explosives(state, player)
+                    ) or
                     can_use_light_arrows(state, player)
-                ),
+                )
             ),
         "Stone Tower Temple Eyegore Room Crates (2)":
             lambda state: (
                 state.has("Zora Mask", player) and
                 (
-                    state.has("Goron Mask", player) or
+                    (
+                        state.has("Goron Mask", player) and
+                        state.has("Small Key (Stone Tower)", player, 1) and
+                        has_explosives(state, player)
+                    ) or
                     can_use_light_arrows(state, player)
                 )
             ),


### PR DESCRIPTION
Fix the missing small key and explosives requirement to access STT's Eyegore Room from the elegy maze side.