### PR TITLE
Tingle Stone Tower Map Logic Fix

### DIFF
--- a/worlds/mm_recomp/NormalRules.py
+++ b/worlds/mm_recomp/NormalRules.py
@@ -2029,14 +2029,17 @@ def get_location_rules(player, options, prices):
 
         "Tingle Stone Tower Map Purchase":
             lambda state: (
-                has_projectiles(state, player) and 
                 (
+                    state.can_reach("Ikana Canyon", 'Region', player) and 
+                    can_use_ice_arrows(state, player) and 
+                    state.has("Hookshot", player)
+                ) or 
+                (
+                    state.can_reach("Great Bay", 'Region', player) and
                     (
-                        state.can_reach("Ikana Canyon", 'Region', player) and 
-                        can_use_ice_arrows(state, player) and 
-                        state.has("Hookshot", player)
-                    ) or 
-                    state.can_reach("Great Bay", 'Region', player)
+                        state.has("Hookshot", player) or
+                        state.has("Progressive Bow", player)
+                    )
                 )
             ),
         "Ikana Canyon Spirit House":


### PR DESCRIPTION
intended as a sort of stop gap fix for public releases (until 1.0 is ready) for Tingle. Since Great Bay Tingle can't be reached with deku bubble nor zora fins. Will submit a separate PR for the 1.0 branch logic later this weekend, since it will need to account for owlsanity 